### PR TITLE
Fix the issue of running multiple livebooks with conflicting servers running

### DIFF
--- a/lib/kino_live_view_native.ex
+++ b/lib/kino_live_view_native.ex
@@ -1,5 +1,4 @@
 defmodule KinoLiveViewNative do
-  require Logger
   use Kino.JS
   use Kino.JS.Live
   use Kino.SmartCell, name: "LiveView Native"
@@ -36,6 +35,7 @@ defmodule KinoLiveViewNative do
         Kino.start_child(Server.Endpoint)
       _ ->
         :os.cmd(:"lsof -t -i tcp:#{port} | xargs kill")
+        # Arbitrary amount of time to wait for server to shutdown.
         Process.sleep(300)
         Logger.error("Port #{port} is already in use. Trying again...")
         start()

--- a/lib/kino_live_view_native.ex
+++ b/lib/kino_live_view_native.ex
@@ -1,8 +1,10 @@
 defmodule KinoLiveViewNative do
+  require Logger
   use Kino.JS
   use Kino.JS.Live
   use Kino.SmartCell, name: "LiveView Native"
   require IEx.Helpers
+  require Logger
 
   def start(opts \\ []) do
     port = Keyword.get(opts, :port, 4000)
@@ -25,8 +27,19 @@ defmodule KinoLiveViewNative do
       ]
     )
 
-    Kino.start_child({Phoenix.PubSub, name: Server.PubSub})
-    Kino.start_child(Server.Endpoint)
+    # Ensures no other servers are running on the same port, which can cause unexpected behavior.
+    {os_processes, _} = System.cmd("lsof", ["-t", "-i", "tcp:#{port}"])
+
+    case os_processes do
+      "" ->
+        Kino.start_child({Phoenix.PubSub, name: Server.PubSub})
+        Kino.start_child(Server.Endpoint)
+      _ ->
+        :os.cmd(:"lsof -t -i tcp:#{port} | xargs kill")
+        Process.sleep(300)
+        Logger.error("Port #{port} is already in use. Trying again...")
+        start()
+    end
   end
 
   @impl true

--- a/lib/kino_live_view_native.ex
+++ b/lib/kino_live_view_native.ex
@@ -38,7 +38,7 @@ defmodule KinoLiveViewNative do
         # Arbitrary amount of time to wait for server to shutdown.
         Process.sleep(300)
         Logger.error("Port #{port} is already in use. Trying again...")
-        start()
+        start(opts)
     end
   end
 


### PR DESCRIPTION
## The Issue:

When running multiple livebooks using kino_live_view_native, each livebook tries to start a server on port 4000. This prevents new livebooks from starting a server on port 4000, thus breaking the experience for students completing multiple guides in a row.

## The Fix:

Detect if any server is running on the configured port (4000 by default) and automatically shut down any servers running on port 4000 before starting the KinoLiveViewNative server. This causes other open livebooks to crash due to their server shutting down.

This may be heavy-handed, so I'm open to suggestions if there's a better path. However, it was the best option I could think of. I had considered an alternative option of having multiple livebooks interact with the same server, but this seemed both technically difficult and potentially error-prone given a student might not consider how changes from two Livebooks could interact.